### PR TITLE
CSC-48: Authentication Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ app.*.map.json
 /ios/firebase_app_id_file.json
 /macos/firebase_app_id_file.json
 /macos/Runner/GoogleService-Info.plist
+/macos/Flutter/GeneratedPluginRegistrant.swift
 /coverage/
 /.firebaserc

--- a/lib/Containers/LoginContainer.dart
+++ b/lib/Containers/LoginContainer.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'State Managers/LoginState.dart';
 
-
+Key pageToggle = Key("Page Toggle Key");
 class LoginContainer extends StatefulWidget
 {
+
   @override
   State<StatefulWidget> createState()
   {
@@ -23,7 +24,22 @@ class LoginContainerState extends State<LoginContainer>
         child: Consumer<LoginState>(
           builder: (context,state,child)
               {
-                return state.activePage;
+                return Stack(
+                  children: [
+                    Container(
+                        key: Key(state.active.index.toString()),
+                        child: state.activePage),
+                    Align(
+                      alignment: Alignment.bottomLeft,
+
+                      //Normalization function to allow to toggle through pages without navigation
+                      child: IconButton(
+                        key: pageToggle,
+                        icon: Icon(Icons.plus_one), onPressed: () {
+                        state.setActive(LoginPages.values[(state.active.index+1) % (LoginPages.values.length)]);
+                      },),),
+                  ],
+                );
               }
         ),
       ),

--- a/lib/Containers/State Managers/LoginState.dart
+++ b/lib/Containers/State Managers/LoginState.dart
@@ -1,21 +1,23 @@
 import 'package:flutter/material.dart';
+import '../../Pages/LandingPage.dart';
+import '../../Pages/LoginPage.dart';
 
 //List of viable login pages
-enum LoginPage { LandingPage, LoginInfoPage, RegisterPage, InfoPage }
+enum LoginPages { LandingPage, LoginPage, RegisterPage, InfoPage }
 
 //Register the properties of login pages
-extension LoginPages on LoginPage {
-  static Map<LoginPage, Widget> pages = {
-    LoginPage.LandingPage: Container(),
-    LoginPage.LoginInfoPage: Container(),
-    LoginPage.RegisterPage: Container(),
-    LoginPage.InfoPage: Container(),
+extension LoginPageExtension on LoginPages {
+  static Map<LoginPages, Widget> pages = {
+    LoginPages.LandingPage: LandingPage(),
+    LoginPages.LoginPage: LoginPage(),
+    LoginPages.RegisterPage: Container(),
+    LoginPages.InfoPage: Container(),
   };
 
   //Unimplemented
   //This allows you to restrict navigation between pages based on requirements.
   // e.g: A user needs to have a valid password/account before continuing.
-  static Map<LoginPage, bool Function()> assertions = {};
+  static Map<LoginPages, bool Function()> assertions = {};
 
   //Route to the page if the assertion function passes and the page exists.
   Widget get page {
@@ -24,9 +26,17 @@ extension LoginPages on LoginPage {
 }
 
 class LoginState extends ChangeNotifier {
-  Widget activePage = LoginPage.LandingPage.page;
+  LoginPages active = LoginPages.LandingPage;
+  Widget activePage = LoginPages.LandingPage.page;
 
-  void setPage(LoginPage routePage) {
+  void setActive(LoginPages routePage)
+  {
+    active = routePage;
+    activePage = routePage.page;
+    notifyListeners();
+  }
+
+  void setPage(LoginPages routePage) {
     activePage = routePage.page;
     notifyListeners(); //setState();
   }

--- a/lib/Pages/LandingPage.dart
+++ b/lib/Pages/LandingPage.dart
@@ -98,7 +98,7 @@ class SmallScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Center(
-              child: new Image.asset("music_swing_logo_small.png", width: 370, height: 338),
+              child: new Image.asset("assets/music_swing_logo_small.png", width: 370, height: 338),
             ),
             Padding(
               padding: EdgeInsets.only(left: 0.0, top: 0),
@@ -162,7 +162,8 @@ class SmallScreen extends StatelessWidget {
   }
 }
 
-class LandingPage extends StatelessWidget {
+class LandingPage extends StatelessWidget
+{
   const LandingPage({super.key});
 
   @override
@@ -174,7 +175,7 @@ class LandingPage extends StatelessWidget {
               decoration:BoxDecoration(
                 //set img to bg of body
                 image: DecorationImage(
-                    image: AssetImage("landingpageBG.png"), fit: BoxFit.cover),
+                    image: AssetImage("assets/landingpageBG.png"), fit: BoxFit.cover),
               ),
               child: Column(
                   children: [Body()]

--- a/lib/Pages/LoginPage.dart
+++ b/lib/Pages/LoginPage.dart
@@ -2,6 +2,20 @@ import 'package:flutter/material.dart';
 import '../Widgets/widgets.dart';
 
 
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: Column(
+            children: [Body()]
+        )
+    );
+  }
+}
+
 class Body extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -306,22 +320,6 @@ class SmallScreen extends StatelessWidget {
           )
         )
       )
-    );
-  }
-}
-
-
-class LoginPage extends StatelessWidget {
-  const LoginPage({super.key});
-
-  @override
-  Widget build(Object context) {
-    //Materialapp debugger false
-    return Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: Column(
-            children: [Body()]
-        )
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'Pages/LoginPage.dart';
+import 'Containers/LoginContainer.dart';
 import 'Widgets/MockNavigator.dart';
 
 void main() {
@@ -33,7 +33,7 @@ class App extends StatelessWidget {
       theme: ThemeData(
           primarySwatch: MaterialColor(0x0d0036, color),
           fontFamily: 'Maven Pro'),
-      home: LoginPage(),
+      home: LoginContainer(),
     );
   }
 }

--- a/test/AuthContainer_test.dart
+++ b/test/AuthContainer_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mood_swing/Containers/LoginContainer.dart';
+import 'package:mood_swing/Containers/State%20Managers/LoginState.dart';
+import 'package:mood_swing/main.dart';
+
+import 'TestUtilities.dart';
+
+void main() {
+  group("Auth Container Tests", () {
+    testWidgets('Test that all pages are navigable',
+        (WidgetTester tester) async {
+      // Build our app and trigger a frame.
+      await tester.pumpWidget(App());
+      TestUtilities().disableOverflowErrors();
+      for (int i = 0; i < LoginPages.values.length-1; i++)  {
+        expect(await find.byKey(Key(i.toString())), findsOneWidget);
+        await tester.tap(find.byKey(pageToggle));
+        await tester.pumpAndSettle();
+      }
+    });
+  });
+}


### PR DESCRIPTION
This PR adds a container to handle navigation between the pages within our authentication flow. There is currently a +1 button in the bottom left-hand corner that allows for navigation to be tested.  The new test code iterates through all the pages to confirm they are renderable.